### PR TITLE
Page transitions, shared-element morph, skeletons and scroll reveal

### DIFF
--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -195,6 +195,113 @@
     transition: transform var(--dur-base) var(--ease-out-quart);
 }
 
+/* Tile hover. The card lifts and takes a stacking context so it sits over its
+   neighbours; the thumbnail inside scales a little further, which is what reads
+   as "looking into" the tile rather than just enlarging it. `focus-within` is
+   here so keyboard users get the same affordance as the mouse. */
+.media-tile {
+    transition: transform var(--dur-base) var(--ease-out-quart);
+}
+
+.media-tile:hover,
+.media-tile:focus-within {
+    position: relative;
+    z-index: 20;
+    transform: scale(1.03);
+}
+
+/* Loading art for a thumbnail whose image has not arrived. The same slow sweep
+   the archive already uses for a still-processing recording, so "loading" and
+   "processing" read as one family rather than two inventions. */
+.media-skeleton {
+    position: absolute;
+    inset: 0;
+    background: linear-gradient(
+        100deg,
+        transparent 35%,
+        color-mix(in oklch, var(--color-primary-200) 10%, transparent) 50%,
+        transparent 65%
+    );
+    background-size: 250% 100%;
+    animation: media-sweep 2.8s ease-in-out infinite;
+}
+
+@keyframes media-sweep {
+    0% { background-position: 150% 0; }
+    100% { background-position: -50% 0; }
+}
+
+/* Scroll reveal, CSS-only via a view timeline: no IntersectionObserver, no JS on
+   the scroll path. Gated on @supports because Firefox has no view() timeline yet,
+   where the rule simply never applies and content is visible as normal.
+   Deliberately not used on `.stream-grid` tiles: they already animate in through
+   <TransitionGroup>, and two systems animating one element fight. */
+@supports (animation-timeline: view()) {
+    @media (prefers-reduced-motion: no-preference) {
+        .reveal {
+            animation: reveal-rise linear both;
+            animation-timeline: view();
+            animation-range: entry 0% entry 55%;
+        }
+    }
+}
+
+@keyframes reveal-rise {
+    from {
+        opacity: 0;
+        transform: translateY(24px);
+    }
+}
+
+/* Page transitions (View Transitions API, wired up in resources/js/viewTransitions.js).
+   The root cross-fade is short on purpose: its job is to stop an Inertia visit
+   reading as a hard cut, not to be an effect anyone notices. */
+::view-transition-old(root),
+::view-transition-new(root) {
+    animation-duration: var(--dur-base);
+    animation-timing-function: var(--ease-out-quart);
+}
+
+::view-transition-old(root) {
+    animation-name: vt-page-out;
+}
+
+::view-transition-new(root) {
+    animation-name: vt-page-in;
+}
+
+@keyframes vt-page-out {
+    to { opacity: 0; }
+}
+
+@keyframes vt-page-in {
+    from {
+        opacity: 0;
+        transform: translateY(8px);
+    }
+}
+
+/* Shared element: the tile a visit started from morphs into the player it lands
+   on. Both ends claim `view-transition-name: media-hero` (see
+   composables/useMediaHero.js), so the browser tweens one box between two pages
+   instead of cross-fading two unrelated rectangles. Both ends are 16:9, so the
+   default crossfade inside the morphing group is enough. */
+::view-transition-group(media-hero) {
+    animation-duration: var(--dur-slow);
+    animation-timing-function: var(--ease-out-expo);
+}
+
+/* The `*` reduced-motion rule below cannot reach view-transition pseudo-elements,
+   so they are turned off explicitly. The JS side also declines to start a
+   transition at all when the setting is on; this is the belt to that braces. */
+@media (prefers-reduced-motion: reduce) {
+    ::view-transition-group(*),
+    ::view-transition-old(*),
+    ::view-transition-new(*) {
+        animation: none !important;
+    }
+}
+
 /* One gate for every animation in the app. Components no longer carry their own
    media query, and motion added later cannot ship without honouring the setting.
    Durations collapse to ~0 rather than to `none` so Vue's <Transition> still gets

--- a/resources/js/Components/Recordings/RecordingTile.vue
+++ b/resources/js/Components/Recordings/RecordingTile.vue
@@ -3,11 +3,15 @@
     :is="isPending ? 'div' : Link"
     :href="isPending ? undefined : route('recordings.show', recording.id)"
     class="group block"
-    :class="{ 'is-pending': isPending }"
+    :class="[{ 'is-pending': isPending }, isPending ? '' : 'media-tile']"
     :aria-disabled="isPending ? 'true' : undefined"
+    :prefetch="isPending ? undefined : true"
+    @pointerdown="isPending || claimMediaHero(thumbnail)"
   >
-    <!-- Thumbnail Container -->
+    <!-- Thumbnail Container. Also the origin of the shared-element morph into the
+         recording player, which is why it carries the ref. -->
     <div
+      ref="thumbnail"
       class="aspect-video relative bg-primary-900 rounded-xl overflow-hidden ring-1 ring-white/5 transition-all duration-(--dur-base)"
       :class="isPending
         ? 'ring-white/10'
@@ -31,6 +35,14 @@
 
       <!-- Placeholder when no thumbnail -->
       <TilePlaceholder v-if="isPending || !recording.thumbnail_url || thumbnailError" :label="isPending ? null : recordingYear" />
+
+      <!-- Loading art for a lazy thumbnail that has not decoded yet. Distinct from
+           the pending shimmer below, which means the recording itself is not ready. -->
+      <div
+        v-else-if="!thumbnailLoaded"
+        class="media-skeleton"
+        aria-hidden="true"
+      />
 
       <!-- Pending: the art is a slow shimmer instead of a spinner, so a grid of
            unprocessed shows reads as one calm surface rather than a wall of spinners. -->
@@ -98,6 +110,7 @@ import { computed, ref } from 'vue';
 import TilePlaceholder from '../TilePlaceholder.vue';
 import FaPlayIcon from '../Icons/FaPlayIcon.vue';
 import FaEyeIcon from '../Icons/FaEyeIcon.vue';
+import { claimMediaHero } from '@/composables/useMediaHero';
 
 // Props
 const props = defineProps({
@@ -116,6 +129,7 @@ const props = defineProps({
 // State
 const thumbnailError = ref(false);
 const thumbnailLoaded = ref(false);
+const thumbnail = ref(null);
 
 // A show that has ended but has no published recording yet. It sits in the same grid
 // as everything else, dimmed and unclickable, so the year does not look like it is

--- a/resources/js/Components/Recordings/RecordingTile.vue
+++ b/resources/js/Components/Recordings/RecordingTile.vue
@@ -6,7 +6,8 @@
     :class="[{ 'is-pending': isPending }, isPending ? '' : 'media-tile']"
     :aria-disabled="isPending ? 'true' : undefined"
     :prefetch="isPending ? undefined : true"
-    @pointerdown="isPending || claimMediaHero(thumbnail)"
+    @pointerdown="claimHero"
+    @keydown.enter="claimHero"
   >
     <!-- Thumbnail Container. Also the origin of the shared-element morph into the
          recording player, which is why it carries the ref. -->
@@ -141,6 +142,15 @@ const isPending = computed(() => Boolean(props.recording.is_pending));
 const recordingYear = computed(() =>
   props.recording.date ? String(new Date(props.recording.date).getFullYear()) : null
 );
+
+// Both activation paths, because Enter on a focused link fires `click` without
+// ever firing `pointerdown`: without the keydown the old page would be captured
+// with nothing named, and keyboard users would lose the morph.
+const claimHero = () => {
+  if (isPending.value) return;
+
+  claimMediaHero(thumbnail.value);
+};
 
 // Methods
 const handleImageError = () => {

--- a/resources/js/Components/Shows/ShowTile.vue
+++ b/resources/js/Components/Shows/ShowTile.vue
@@ -11,7 +11,8 @@
       :href="route('show.view', show.slug)"
       class="group block"
       prefetch
-      @pointerdown="claimMediaHero(thumbnail)"
+      @pointerdown="claimHero"
+      @keydown.enter="claimHero"
     >
       <!-- Thumbnail Container. Also the origin of the shared-element morph into
            the player, which is why it carries the ref. -->
@@ -195,6 +196,11 @@ const streamUrl = computed(() => {
 });
 
 // Methods
+// Both activation paths, because Enter on a focused link fires `click` without
+// ever firing `pointerdown`: without the keydown the old page would be captured
+// with nothing named, and keyboard users would lose the morph.
+const claimHero = () => claimMediaHero(thumbnail.value);
+
 const handleImageError = () => {
   currentThumbnail.value = null;
   thumbnailLoaded.value = false;

--- a/resources/js/Components/Shows/ShowTile.vue
+++ b/resources/js/Components/Shows/ShowTile.vue
@@ -2,14 +2,23 @@
   <div
     @mouseenter="handleMouseEnter"
     @mouseleave="handleMouseLeave"
-    class="show-tile-wrapper"
+    class="show-tile-wrapper media-tile"
   >
+    <!-- `prefetch` is what makes the view transition worth having: the response is
+         usually already cached by the time the click lands, so the morph starts
+         immediately instead of after a round trip spent frozen. -->
     <Link
       :href="route('show.view', show.slug)"
       class="group block"
+      prefetch
+      @pointerdown="claimMediaHero(thumbnail)"
     >
-      <!-- Thumbnail Container -->
-      <div class="relative aspect-video rounded-xl overflow-hidden bg-primary-800 ring-1 ring-white/5 group-hover:ring-2 group-hover:ring-primary-500/60 group-hover:shadow-lg group-hover:shadow-primary-500/20 transition-all duration-(--dur-base)">
+      <!-- Thumbnail Container. Also the origin of the shared-element morph into
+           the player, which is why it carries the ref. -->
+      <div
+        ref="thumbnail"
+        class="relative aspect-video rounded-xl overflow-hidden bg-primary-800 ring-1 ring-white/5 group-hover:ring-2 group-hover:ring-primary-500/60 group-hover:shadow-lg group-hover:shadow-primary-500/20 transition-all duration-(--dur-base)"
+      >
         <!-- Video Preview (only for live shows) -->
         <Transition
           enter-active-class="transition-all duration-(--dur-slower) ease-(--ease-out-expo)"
@@ -57,6 +66,14 @@
         <TilePlaceholder
           v-if="!currentThumbnail && !showVideoPreview"
           :label="show.source"
+        />
+
+        <!-- Loading art for a lazy thumbnail that has not decoded yet, so a grid
+             scrolled into view sweeps instead of showing flat boxes. -->
+        <div
+          v-else-if="currentThumbnail && !thumbnailLoaded && !showVideoPreview"
+          class="media-skeleton"
+          aria-hidden="true"
         />
 
         <!-- Top badges row -->
@@ -125,6 +142,7 @@ import FaPlayIcon from '../Icons/FaPlayIcon.vue';
 import FaUsersIcon from '../Icons/FaUsersIcon.vue';
 import Hls from 'hls.js';
 import { useNow } from '@/composables/useNow';
+import { claimMediaHero } from '@/composables/useMediaHero';
 
 // Props
 const props = defineProps({
@@ -143,6 +161,7 @@ const props = defineProps({
 // Reactive state
 const currentThumbnail = ref(props.show.thumbnail_url);
 const thumbnailLoaded = ref(false);
+const thumbnail = ref(null);
 const showVideoPreview = ref(false);
 const videoPreview = ref(null);
 let hoverTimeout = null;

--- a/resources/js/Pages/Archive/Index.vue
+++ b/resources/js/Pages/Archive/Index.vue
@@ -57,7 +57,8 @@
             v-for="(collection, index) in collections"
             :key="collection.year"
             :href="route('recordings.year', collection.year)"
-            class="collection-card group"
+            class="collection-card group reveal"
+            prefetch
           >
             <div class="collection-art">
               <img
@@ -67,9 +68,17 @@
                 :loading="index < 4 ? 'eager' : 'lazy'"
                 :fetchpriority="index < 4 ? 'high' : 'auto'"
                 decoding="async"
-                class="absolute inset-0 h-full w-full object-cover transition-transform duration-(--dur-slow) ease-(--ease-out-expo) group-hover:scale-105"
+                class="absolute inset-0 h-full w-full object-cover transition-[opacity,transform] duration-(--dur-slow) ease-(--ease-out-expo) group-hover:scale-105"
+                :class="loadedArt[collection.year] ? 'opacity-100' : 'opacity-0'"
+                @load="loadedArt[collection.year] = true"
               />
               <TilePlaceholder v-else />
+
+              <div
+                v-if="collection.thumbnail_url && !loadedArt[collection.year]"
+                class="media-skeleton"
+                aria-hidden="true"
+              />
 
               <div class="collection-scrim" />
 
@@ -128,7 +137,7 @@
 
 <script setup>
 import { Head, Link, router } from '@inertiajs/vue3';
-import { ref } from 'vue';
+import { reactive, ref } from 'vue';
 import AuthenticatedLayout from '@/Layouts/AuthenticatedLayout.vue';
 import RecordingTile from '@/Components/Recordings/RecordingTile.vue';
 import TilePlaceholder from '@/Components/TilePlaceholder.vue';
@@ -148,6 +157,9 @@ const props = defineProps({
 });
 
 const searchQuery = ref(props.search ?? '');
+
+// Keyed by year: collection art fades in when its own bytes land, same as a tile.
+const loadedArt = reactive({});
 
 const submitSearch = () => {
   router.get(

--- a/resources/js/Pages/Archive/Index.vue
+++ b/resources/js/Pages/Archive/Index.vue
@@ -62,20 +62,24 @@
           >
             <div class="collection-art">
               <img
-                v-if="collection.thumbnail_url"
+                v-if="collection.thumbnail_url && artState[collection.year] !== 'failed'"
                 :src="collection.thumbnail_url"
                 :alt="`${collection.year} collection`"
                 :loading="index < 4 ? 'eager' : 'lazy'"
                 :fetchpriority="index < 4 ? 'high' : 'auto'"
                 decoding="async"
                 class="absolute inset-0 h-full w-full object-cover transition-[opacity,transform] duration-(--dur-slow) ease-(--ease-out-expo) group-hover:scale-105"
-                :class="loadedArt[collection.year] ? 'opacity-100' : 'opacity-0'"
-                @load="loadedArt[collection.year] = true"
+                :class="artState[collection.year] === 'loaded' ? 'opacity-100' : 'opacity-0'"
+                @load="artState[collection.year] = 'loaded'"
+                @error="artState[collection.year] = 'failed'"
               />
               <TilePlaceholder v-else />
 
+              <!-- Only while the art is genuinely in flight. A failed request sets
+                   `failed` too, so the sweep stops and the placeholder takes over
+                   rather than shimmering at an image that is never coming. -->
               <div
-                v-if="collection.thumbnail_url && !loadedArt[collection.year]"
+                v-if="collection.thumbnail_url && !artState[collection.year]"
                 class="media-skeleton"
                 aria-hidden="true"
               />
@@ -158,8 +162,9 @@ const props = defineProps({
 
 const searchQuery = ref(props.search ?? '');
 
-// Keyed by year: collection art fades in when its own bytes land, same as a tile.
-const loadedArt = reactive({});
+// Keyed by year, 'loaded' | 'failed': collection art fades in when its own bytes
+// land, same as a tile, and falls back to the placeholder when they never do.
+const artState = reactive({});
 
 const submitSearch = () => {
   router.get(

--- a/resources/js/Pages/RecordingPlayer.vue
+++ b/resources/js/Pages/RecordingPlayer.vue
@@ -23,8 +23,11 @@
                         </button>
                     </div>
 
+                    <!-- Landing half of the shared-element morph from the archive
+                         tile. See composables/useMediaHero.js. -->
                     <VideoPlayer
                         :key="playerKey"
+                        v-media-hero
                         :src="recording.m3u8_url"
                         :title="recording.title"
                         :poster="recording.thumbnail_url"

--- a/resources/js/Pages/Schedule.vue
+++ b/resources/js/Pages/Schedule.vue
@@ -35,7 +35,9 @@
             <span class="now-marker-label tabular-nums">{{ nowClock }}</span>
           </li>
 
-          <li>
+          <!-- `reveal` is a scroll-driven fade handled entirely in CSS; a full day's
+               programme is a long list and this gives it a sense of arriving. -->
+          <li class="reveal">
             <Link :href="route('show.view', entry.slug)" class="agenda-row" :class="rowClass(entry)">
               <span class="agenda-time">
                 <span class="agenda-start tabular-nums">{{ formatClock(entry.scheduled_start) }}</span>

--- a/resources/js/Pages/ShowPlayer.vue
+++ b/resources/js/Pages/ShowPlayer.vue
@@ -504,7 +504,11 @@ onUnmounted(() => {
                 <!-- Scrollable Content Area -->
                 <div class="flex-1 overflow-auto">
                     <div v-if="showPlayer">
+                        <!-- Landing half of the shared-element morph: the tile that
+                             was clicked on the browse grid tweens into this box.
+                             See composables/useMediaHero.js. -->
                         <StreamPlayer ref="streamPlayer"
+                                      v-media-hero
                                       :hls-url="hlsUrl"
                                       :show-info="activeShow"
                                       class="z-10 relative w-full bg-black mx-auto"

--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -7,6 +7,8 @@ import {resolvePageComponent} from 'laravel-vite-plugin/inertia-helpers';
 import { ZiggyVue } from '../../vendor/tightenco/ziggy';
 import VueCookies from 'vue-cookies'
 import VueAxios from "vue-axios";
+import { installViewTransitions } from './viewTransitions';
+import { mediaHeroDirective } from './composables/useMediaHero';
 
 // Read the shared branding off the initial Inertia payload so the tab title and
 // progress bar follow whatever this installation is branded as, rather than a
@@ -26,6 +28,7 @@ createInertiaApp({
             .use(ZiggyVue, Ziggy)
             .use(VueCookies, {})
             .use(VueAxios, axios)
+            .directive('media-hero', mediaHeroDirective)
             .provide('axios', {
                 get: axios.get,
                 post: axios.post,
@@ -38,3 +41,8 @@ createInertiaApp({
         color: progressColor,
     },
 });
+
+// Registered after the app so the router exists. A no-op in a browser without the
+// View Transitions API, and for anyone who has asked for reduced motion;
+// navigation falls back to the plain Inertia swap.
+installViewTransitions();

--- a/resources/js/composables/useMediaHero.js
+++ b/resources/js/composables/useMediaHero.js
@@ -1,0 +1,36 @@
+import { supportsViewTransitions } from '@/viewTransitions';
+
+// A `view-transition-name` has to be unique in the document, so exactly one
+// element may wear this at a time. A browse grid has forty thumbnails that could
+// all plausibly be the origin of the morph, and a player page renders both a
+// player and a sidebar of tiles, so ownership is tracked here in one place:
+// claiming always takes the name off whoever held it last.
+const MEDIA_HERO = 'media-hero';
+
+let holder = null;
+
+export function claimMediaHero(el) {
+    if (!supportsViewTransitions()) return;
+    if (holder === el) return;
+
+    if (holder) holder.style.viewTransitionName = '';
+
+    holder = el ?? null;
+
+    if (holder) holder.style.viewTransitionName = MEDIA_HERO;
+}
+
+// The landing half of the morph: a player claims the name for as long as it is on
+// screen. `updated` re-asserts it because Inertia reuses the player component
+// between two show pages, so `mounted` fires only once, and because a tile in the
+// same page's sidebar takes the name away when it is clicked.
+export const mediaHeroDirective = {
+    mounted: (el) => claimMediaHero(el),
+    updated: (el) => claimMediaHero(el),
+    unmounted: (el) => {
+        if (holder === el) {
+            el.style.viewTransitionName = '';
+            holder = null;
+        }
+    },
+};

--- a/resources/js/viewTransitions.js
+++ b/resources/js/viewTransitions.js
@@ -1,0 +1,71 @@
+import { router } from '@inertiajs/vue3';
+
+// Longest a page may sit under a captured snapshot before the transition is
+// released un-animated. While a view transition is pending the browser suppresses
+// painting, so a slow visit would otherwise look hung: the progress bar itself is
+// part of the frozen snapshot and would stop moving. Tiles prefetch on hover, so
+// in practice the response is already cached and this never fires.
+const MAX_FREEZE_MS = 600;
+
+let releasePending = null;
+let releaseTimer = null;
+
+export function prefersReducedMotion() {
+    return window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+}
+
+export function supportsViewTransitions() {
+    return typeof document.startViewTransition === 'function' && !prefersReducedMotion();
+}
+
+// Let the browser take its "after" snapshot and animate. Safe to call twice.
+function release() {
+    if (releaseTimer) {
+        clearTimeout(releaseTimer);
+        releaseTimer = null;
+    }
+
+    const resolve = releasePending;
+    releasePending = null;
+    resolve?.();
+}
+
+export function installViewTransitions() {
+    router.on('before', (event) => {
+        // A visit fired while one is still animating: let the first one land
+        // rather than stacking two transitions on the same document.
+        if (releasePending) {
+            release();
+            return;
+        }
+
+        if (!supportsViewTransitions()) return;
+
+        // Only whole-page navigations get a transition.
+        //
+        // A POST that re-renders the same form has nothing to morph. Neither does
+        // a partial or preserve-state visit, and those are the ones that must not
+        // freeze: the manage tables re-query on every filter and keystroke
+        // (Components/Manage/useTableQuery.js), and a snapshot over the page each
+        // time would make typing feel broken.
+        const visit = event.detail?.visit;
+        if (!visit) return;
+        if (String(visit.method ?? 'get').toLowerCase() !== 'get') return;
+        if (visit.preserveState) return;
+        if (visit.only?.length || visit.except?.length) return;
+
+        // Inertia has no "about to swap" hook, so the transition is held open
+        // across the request and closed on `finish`, by which point the new page
+        // is in the DOM. The DOM still mutates normally while held; only painting
+        // is suppressed.
+        document.startViewTransition(
+            () =>
+                new Promise((resolve) => {
+                    releasePending = resolve;
+                    releaseTimer = setTimeout(release, MAX_FREEZE_MS);
+                })
+        );
+    });
+
+    router.on('finish', release);
+}


### PR DESCRIPTION
Builds on the motion tokens already on `main` (`--dur-*`, `--ease-*`, the `tile`
TransitionGroup, the reduced-motion gate) and adds the pieces that were left over:
page transitions, a shared-element morph from tile to player, thumbnail skeletons,
scroll reveal, and a hover lift.

## Page transitions

`resources/js/viewTransitions.js` wires the View Transitions API into the Inertia
router. Inertia has no "about to swap" hook, so the transition is held open across
the request and closed on `finish`, by which point the new page is in the DOM. The
DOM still mutates normally while it is held; only painting is suppressed.

Three guards make that safe:

- **`MAX_FREEZE_MS = 600`.** While a transition is pending the browser suppresses
  paint, and that includes Inertia's own progress bar. Past the cap the transition
  is released un-animated so a slow visit degrades to a plain swap instead of
  looking hung.
- **`preserveState` and partial visits are skipped.** `Components/Manage/useTableQuery.js`
  fires a `router.get` on every filter change and every debounced keystroke. A
  snapshot over the page each time would make typing feel broken. Same reasoning
  for the archive search.
- **Non-GET is skipped**, and the whole thing is a no-op without
  `document.startViewTransition` or under `prefers-reduced-motion`.

Root crossfade plus an 8px rise at `--dur-base`.

Tiles and archive collection cards now use Inertia `prefetch`. That is what makes
the transition worth having: the response is usually already cached when the click
lands, so the morph starts immediately rather than after a round trip spent frozen.

## Shared element (tile to player)

`view-transition-name` has to be unique document-wide, and `ShowPlayer` renders
both a player and a sidebar of tiles, so ownership lives in one module
(`composables/useMediaHero.js`) where claiming always strips the name off whoever
held it last.

- Tiles claim on `pointerdown`, before Inertia starts the visit.
- Players claim through a `v-media-hero` directive on `mounted` **and** `updated` —
  Inertia reuses the player component between two show pages, so `mounted` only
  fires once, and a sidebar tile takes the name away when it is clicked.

Worth noting for review: releasing the name from a `router.on('finish')` handler
does not work. It strips the name before the browser captures the new page, so the
morph silently does not happen. The directive's ownership model replaced that.

## Thumbnail skeletons

`.media-skeleton` reuses the archive's existing `pending-sweep` gradient, so
"image still loading" and "recording still processing" read as one family rather
than two separate inventions. It shows while a lazy thumbnail has not decoded yet,
which is a real state now that tile images are lazy — previously those slots were
flat `bg-primary-800` boxes. Applied in both tiles and the archive collection art.

## Scroll reveal

CSS-only, via `animation-timeline: view()`. No IntersectionObserver, nothing
running on the scroll path. Behind `@supports` (Firefox has no view timeline yet,
where the rule simply never applies) and `prefers-reduced-motion: no-preference`.

Applied to schedule rows and archive collection cards, and deliberately *not* to
`.stream-grid` tiles: those already animate in through `<TransitionGroup>`, and two
systems animating one element fight each other.

## Tile hover

`.media-tile` scales to 1.03 and takes `position: relative; z-index: 20` so the
hovered card sits over its neighbours. `:focus-within` is included so keyboard
users get the same affordance. Pending archive tiles are excluded, since they are
not clickable.

## Testing

`vite build` passes and the generated CSS was checked for the new rules. **Not
runtime-verified** — the browser profile was in use, so the transitions and the
morph have not been driven in a real page yet. Worth an eyeball on:

- browse grid to a show, and archive tile to a recording (the morph)
- a manage table filter and the archive search (should *not* transition)
- schedule scrolled top to bottom (reveal)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added smoother page transitions and shared artwork animations when opening recordings, shows, and streams.
  * Added loading skeletons for thumbnails and collection artwork while images load.
  * Added scroll-based reveal animations for collections and schedule entries.
  * Added prefetching for eligible recordings, shows, and collections.
* **Accessibility**
  * Added reduced-motion support to disable transition effects when requested.
* **Visual Improvements**
  * Added hover and focus scaling for interactive media tiles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->